### PR TITLE
fix(yt): replace ytdl-core-discord with ytdl-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,7 +1251,8 @@
     "@types/node": {
       "version": "14.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -6205,19 +6206,12 @@
       "dev": true
     },
     "m3u8stream": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.7.1.tgz",
-      "integrity": "sha512-z6ldnAdhbuWOL6LmMkwptSZGzj+qbRytMKLTbNicwF/bJMjf9U9lqD57RNQUFecvWadEkzy6PDjcNJFFgi19uQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.3.tgz",
+      "integrity": "sha512-0nAcdrF8YJKUkb6PzWdvGftTPyCVWgoiot1AkNVbPKTeIGsWs6DrOjifrJ0Zi8WQfQmD2SuVCjkYIOip12igng==",
       "requires": {
-        "miniget": "^1.6.1",
+        "miniget": "^4.0.0",
         "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "miniget": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/miniget/-/miniget-1.7.2.tgz",
-          "integrity": "sha512-USPNNK2bnHLOplX8BZVMehUkyQizS/DFpBdoH0TS+fM+hQoLNg9tWg4MeY9wE8gfY0pbzmx5UBEODujt3Lz8AA=="
-        }
       }
     },
     "make-dir": {
@@ -6335,9 +6329,9 @@
       "dev": true
     },
     "miniget": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-2.0.2.tgz",
-      "integrity": "sha512-rUYQiHXVjisRIuEdvIQxXPsAKp9Gltz5JdLWA8a3c/5265f2bZudg5mGtWcox0HHxkw51v8od/jLsqyYlM8UBw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.1.0.tgz",
+      "integrity": "sha512-kzhrNv5L7LlomwGmPGQsLQ2PnT1LeJJWfB0wNFGyv426gEM1gsfziBQmfkr6XOBA8EusZg9nowlNT5CbuKTjZg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7121,9 +7115,9 @@
       }
     },
     "prism-media": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.2.tgz",
-      "integrity": "sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.3.tgz",
+      "integrity": "sha512-fSrR66n0l6roW9Rx4rSLMyTPTjRTiXy5RVqDOurACQ6si1rKHHKDU5gwBJoCsIV0R3o9gi+K50akl/qyw1C74A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -9225,24 +9219,14 @@
       }
     },
     "ytdl-core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-3.4.2.tgz",
-      "integrity": "sha512-R6m1XZQK+iXxb9Q9Wo14/K8mti1r4HnKv4zKrbp5FvMG/jDbeV0xQHUHqqDLk+uiDy/VU6fVATm5x2ms0QaF5w==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.1.4.tgz",
+      "integrity": "sha512-f9M2ctrQNH9/X+jOZ/4iA4h6DvNcyuJ+fDvacheeaxtV7sX13qaNmQgNAe7UeTlJWh7Dn3RHQ6imqJJh5beGQg==",
       "requires": {
         "html-entities": "^1.3.1",
-        "m3u8stream": "^0.7.1",
-        "miniget": "^2.0.1",
+        "m3u8stream": "^0.8.3",
+        "miniget": "^4.0.0",
         "sax": "^1.1.3"
-      }
-    },
-    "ytdl-core-discord": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/ytdl-core-discord/-/ytdl-core-discord-1.2.4.tgz",
-      "integrity": "sha512-1FjjwcFHuzDHk3ZJ15GM1gIj874qqLFQ0tTNDYUCsIWCmMzipP5qDjAW4v3sbIzdk22gyLFymh8t8VuYb9a6Lg==",
-      "requires": {
-        "@types/node": "^14.14.2",
-        "prism-media": "^1.2.2",
-        "ytdl-core": "^3.4.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "lodash": "^4.17.20",
     "nunjucks": "^3.2.2",
     "pino": "^6.7.0",
+    "prism-media": "^1.2.3",
     "yargs": "^16.1.1",
-    "ytdl-core-discord": "^1.2.4"
+    "ytdl-core": "^4.1.4"
   },
   "devDependencies": {
     "@prisma/cli": "^2.12.1",

--- a/src/player/yt.ts
+++ b/src/player/yt.ts
@@ -1,17 +1,37 @@
 import { StreamDispatcher, StreamOptions, VoiceConnection } from 'discord.js';
-import ytdl from 'ytdl-core-discord';
+import prism from 'prism-media';
+import ytdl from 'ytdl-core';
 
+import { FriendlyError } from '../error';
 import { Player } from '../types';
+
+export const filter = (format: ytdl.videoFormat): boolean => {
+    return format.codecs === 'opus' && format.container === 'webm' && format.audioSampleRate === '48000';
+};
+
+const canDemux = (info: ytdl.videoInfo) => {
+    return info.formats.find(filter) && info.videoDetails.lengthSeconds !== '0';
+};
 
 export default class YouTube implements Player {
     async play(location: string, connection: VoiceConnection, options: StreamOptions = {}): Promise<StreamDispatcher> {
-        options.type = 'opus';
-        return connection.play(await ytdl(location, { highWaterMark: 1 << 25 }), options);
+        const info = await ytdl.getInfo(location);
+        const demuxer = new prism.opus.WebmDemuxer();
+        const stream = ytdl
+            .downloadFromInfo(info, { highWaterMark: 1 << 25, filter })
+            .pipe(demuxer)
+            .on('end', () => demuxer.destroy());
+
+        return connection.play(stream, { ...options, type: 'opus' });
     }
 
     async getTitle(location: string): Promise<string | null> {
-        const info = await ytdl.getBasicInfo(location);
-        return info.title;
+        const info = await ytdl.getInfo(location);
+        if (!canDemux(info)) {
+            throw new FriendlyError('Video is not supported.');
+        }
+
+        return info.videoDetails.title;
     }
 
     supports(location: string): boolean {


### PR DESCRIPTION
The package seems to have disapeared from GitHub and is currently broken. Replace is using ytdl-core
directly and most of what the module was doing, except we only play opus/webm streams. To compensate
for the change, check the video on add and throw an error if an opus stream doesn't exist.

BREAKING CHANGE: Limited number of video formats that are playable to keep code simple