### PR TITLE
refactor(bot): allow songs to be given directly to the play command

### DIFF
--- a/src/commands/__snapshots__/index.test.ts.snap
+++ b/src/commands/__snapshots__/index.test.ts.snap
@@ -158,8 +158,8 @@ exports[`_help returns the details for the play command 1`] = `
     Array [
       Array [
         "**play**: Start a playlist",
-        "*aliases*: start",
-        "*usage*: \`_play [...TAGS] [--volume|-v VOLUME]\`",
+        "*aliases*: start, playlist",
+        "*usage*: \`_play ...TAGS|SONG [--volume|-v VOLUME]\`",
       ],
       Object {
         "split": true,
@@ -175,8 +175,8 @@ exports[`_help returns the details for the play command 1`] = `
             Array [
               Array [
                 "**play**: Start a playlist",
-                "*aliases*: start",
-                "*usage*: \`_play [...TAGS] [--volume|-v VOLUME]\`",
+                "*aliases*: start, playlist",
+                "*usage*: \`_play ...TAGS|SONG [--volume|-v VOLUME]\`",
               ],
               Object {
                 "split": true,

--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -1,10 +1,12 @@
 import { join } from '@prisma/client';
 import { Message } from 'discord.js';
+import { partition } from 'lodash';
 import { Arguments } from 'yargs';
 
 import db from '../db';
 import { FriendlyError } from '../error';
 import { hasPermission } from '../permission';
+import player from '../player';
 import playlist from '../playlist';
 import { Command } from '../types';
 import next from './next';
@@ -12,8 +14,8 @@ import next from './next';
 const command: Command = {
     name: 'play',
     description: 'Start a playlist',
-    alias: ['start'],
-    usage: '[...TAGS] [--volume|-v VOLUME]',
+    alias: ['start', 'playlist'],
+    usage: '...TAGS|SONG [--volume|-v VOLUME]',
     async run(message: Message, args: Arguments) {
         if (!message.member || !message.member.voice.channel) {
             throw new FriendlyError('You are not in a voice channel');
@@ -23,30 +25,36 @@ const command: Command = {
             throw new FriendlyError('You do not have permission to do that.');
         }
 
+        if (0 === args._.length) {
+            throw new FriendlyError('Please give me something to play.');
+        }
+
+        const [songs, tags] = partition(args._, (arg) => player.supports(arg));
+
         const guild = message.member.voice.channel.guild.name;
         const room = message.member.voice.channel.name;
-        const tags = args._.map((t) => t.toString());
 
-        const results: { location: string }[] = await db.$queryRaw`SELECT S.location
-        FROM songs S
-        JOIN tags T ON T.song_id = S.id
-        WHERE T.tag IN (${join(tags)})
-        AND (S.guild IS NULL OR S.guild = ${message.guild?.id})
-        GROUP BY S.id
-        HAVING COUNT(T.id) = ${tags.length}
-        ORDER BY RANDOM()`;
-        if (0 === results.length) {
-            throw new FriendlyError(`No songs matching "${tags.join(', ')}" were found`);
+        if (0 !== tags.length) {
+            const results: { location: string }[] = await db.$queryRaw`
+            SELECT S.location
+            FROM songs S
+            JOIN tags T ON T.song_id = S.id
+            WHERE T.tag IN (${join(tags)})
+            AND (S.guild IS NULL OR S.guild = ${message.guild?.id})
+            GROUP BY S.id
+            HAVING COUNT(T.id) = ${tags.length}
+            ORDER BY RANDOM()`;
+            if (0 === results.length) {
+                throw new FriendlyError(`No songs matching "${tags.join(', ')}" were found`);
+            }
+
+            songs.push(...results.map((r) => r.location));
         }
 
         playlist.clear(guild, room);
-        playlist.create(
-            guild,
-            room,
-            results.map((r) => r.location),
-        );
+        playlist.create(guild, room, songs);
 
-        await next.run(message, args);
+        return await next.run(message, args);
     },
 };
 


### PR DESCRIPTION
Allow for playing one-off songs without adding them first by splitting up values that have a
supported player and tags.

fix #118